### PR TITLE
feat: added phpMyAdmin deployment to manage MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,33 @@ If the output shows a node in **Ready** state, the cluster is successfully set u
 
 ---
 
+## **Deploying MySQL and phpMyAdmin with Minikube**
 
+### **1. Setup Script**
+A `setup.sh` script is provided to automate the deployment of MySQL and phpMyAdmin.
+
+#### **How to Run the Script**
+```bash
+chmod +x setup.sh
+./setup.sh
+```
+This will:
+- Start Minikube if it's not already running.
+- Deploy MySQL and phpMyAdmin.
+- Wait for MySQL to be ready before proceeding.
+
+### **2. Access phpMyAdmin**
+Once the script completes, you can access phpMyAdmin using Minikube’s IP:
+
+```bash
+minikube ip
+```
+Copy the IP address and open the following URL in your browser:
+
+```
+http://<MINIKUBE_IP>:30001
+```
+
+### **3. Login Credentials**
+- **Username:** `root`
+- **Password:** (stored in Kubernetes Secret, default: `rootpassword`)

--- a/k8s/phpmyadmin-deployment.yaml
+++ b/k8s/phpmyadmin-deployment.yaml
@@ -1,1 +1,32 @@
-
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: phpmyadmin-deployment
+  namespace: default
+  labels:
+    app: phpmyadmin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: phpmyadmin
+  template:
+    metadata:
+      labels:
+        app: phpmyadmin
+    spec:
+      containers:
+        - name: phpmyadmin
+          image: phpmyadmin/phpmyadmin:latest
+          env:
+            - name: PMA_HOST
+              value: mysql-service
+            - name: PMA_USER
+              value: root
+            - name: PMA_PASSWORD
+              valueFrom:
+                  secretKeyRef:
+                    name: mysql-secret
+                    key: MYSQL_ROOT_PASSWORD
+          ports:
+            - containerPort: 80

--- a/k8s/phpmyadmin-service.yaml
+++ b/k8s/phpmyadmin-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: phpmyadmin-service
+  namespace: default
+  labels:
+    app: phpmyadmin
+spec:
+  type: NodePort
+  selector:
+    app: phpmyadmin
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+      nodePort: 30001

--- a/setup.sh
+++ b/setup.sh
@@ -20,6 +20,9 @@ kubectl apply -f k8s/mysql-secret.yaml
 kubectl apply -f k8s/mysql-pvc.yaml
 kubectl apply -f k8s/mysql-deployment.yaml
 kubectl apply -f k8s/mysql-service.yaml
+kubectl apply -f k8s/phpmyadmin-deployment.yaml
+kubectl apply -f k8s/phpmyadmin-service.yaml
+
 
 # Esperar a que MySQL esté listo
 echo "Waiting for MySQL pod to be ready..."


### PR DESCRIPTION
### **What does this PR do?**
This PR adds the **phpMyAdmin** deployment, allowing users to manage the MySQL database via a web UI. It includes:
- A **Deployment** for phpMyAdmin.
- A **NodePort Service** to expose phpMyAdmin (`http://<MINIKUBE_IP>:30001`).
- Updates to `setup.sh` for automatic deployment.
- Updates to the `README.md` with access instructions.

### **Why is this needed?**
- Provides an easy way to interact with MySQL.
- Eliminates the need for direct terminal SQL commands.

### **How to test it?**
1. Start Minikube:
   ```bash
   minikube start
   ```
2. Run the setup script:
   ```bash
   ./setup.sh
   ```
3. Get Minikube's IP and access:
   ```bash
   minikube ip
   ```
   Open `http://<MINIKUBE_IP>:30001` in your browser.

